### PR TITLE
BSIDM-349 Remove check at module install

### DIFF
--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Sale Credit Points',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
+from odoo import tools
 
 
 class SaleOrder(models.Model):
@@ -29,8 +30,15 @@ class SaleOrder(models.Model):
     @api.multi
     def action_confirm(self):
         """Check credit before confirmation, update credit if check passed."""
-        for sale in self:
-            sale.credit_point_check()
-            sale.partner_id.credit_point_decrease(
-                sale.amount_total, comment=self.credit_point_decrease_msg)
+        install_module = tools.config.get('init')
+        """
+        At installation, odoo core demo data is calling  on SO.
+        It was leading to an error related to this module, as the demo partner
+        didn't had any credit point
+        """
+        if 'sale_credit_point' not in install_module:
+            for sale in self:
+                sale.credit_point_check()
+                sale.partner_id.credit_point_decrease(
+                    sale.amount_total, comment=self.credit_point_decrease_msg)
         return super().action_confirm()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -31,11 +31,10 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         """Check credit before confirmation, update credit if check passed."""
         install_module = tools.config.get('init')
-        """
-        At installation, odoo core demo data is calling  on SO.
-        It was leading to an error related to this module, as the demo partner
-        didn't had any credit point
-        """
+        # At installation, odoo core demo data is calling  on SO.
+        # It was leading to an error related to this module, as the demo
+        # partner didn't had any credit point
+
         if 'sale_credit_point' not in install_module:
             for sale in self:
                 sale.credit_point_check()

--- a/sale_credit_point/views/point_history.xml
+++ b/sale_credit_point/views/point_history.xml
@@ -10,7 +10,6 @@
                 <field name="operation" readonly="True"/>
                 <field name="amount" readonly="True"/>
                 <field name="credit_point_currency_id" readonly="True"/>
-                <field name="credit_point_currency_id" readonly="True" invisible="1" />
                 <field name="create_date" readonly="True"/>
                 <field name="comment" readonly="True"/>
             </tree>


### PR DESCRIPTION
At installation, odoo core demo data is calling  on SO.
It was leading to an error related to this module, as the demo partner
didn't had any credit point

- it passes the tests locally
- integrated as a pending-merge in https://github.com/camptocamp/idmatos_odoo/pull/79