### PR TITLE
[FIX] check on website sale orders

### DIFF
--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Sale Credit Points',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.0.3',
     'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -9,10 +9,15 @@ from odoo import tools
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def credit_point_check(self):
+    def credit_point_check(self, user=None):
         """Verify order amount against credit point budget."""
+        # Introduced this check as from website sale_orders are created
+        # from admin. If admin is in manage_credits group - all users will
+        # bypass check. This way, we can check specific user from request
+        if not user:
+            user = self.env.user
         self.ensure_one()
-        if not self.partner_id.credit_point_bypass_check():
+        if not self.partner_id.sudo(user.id).credit_point_bypass_check():
             if self.amount_total > self.partner_id.credit_point:
                 raise UserError(self.credit_point_check_failed_msg)
 

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -13,6 +13,16 @@ class TestSaleOrder(TestSale):
         self.product.list_price = 10
         self.product.currency_id = \
             self.env['res.partner']._default_credit_point_currency_id()
+        self.admin = self.env['res.users'].browse(1)
+        self.admin.groups_id = [(4, self.env.ref(
+            'sale_credit_point.group_manage_credit_point'
+        ).id)]
+        self.portal_user = self.env["res.users"].create({
+            'login': 'Ducky_McDuckface',
+            'name': 'Ducky McDuckface',
+            'email': 'duck@tales.woohoo',
+        })
+        self.portal_user.partner_id.credit_point = 0
 
     def _create_so(self):
         self.product = self.products['prod_order']
@@ -78,3 +88,15 @@ class TestSaleOrder(TestSale):
         so2.action_cancel()
         self.assertEqual(so2.state, 'cancel')
         self.assertEqual(so2.partner_id.credit_point, 100)
+
+    def test_so_credit_check_user(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 0
+        with self.assertRaises(exceptions.UserError):
+            # portal user doesn't have the rights
+            so.sudo(self.portal_user.id).credit_point_check()
+        with self.assertRaises(exceptions.UserError):
+            # nor can handle it via sudo with passing of the user
+            so.sudo().credit_point_check(self.portal_user)
+        # admin still can confirm it without check
+        self.assertTrue(so.sudo().credit_point_check() is None)

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -13,15 +13,10 @@ class TestSaleOrder(TestSale):
         self.product.list_price = 10
         self.product.currency_id = \
             self.env['res.partner']._default_credit_point_currency_id()
-        self.admin = self.env['res.users'].browse(1)
-        self.admin.groups_id = [(4, self.env.ref(
+        self.env.user.groups_id = [(4, self.env.ref(
             'sale_credit_point.group_manage_credit_point'
         ).id)]
-        self.portal_user = self.env["res.users"].create({
-            'login': 'Ducky_McDuckface',
-            'name': 'Ducky McDuckface',
-            'email': 'duck@tales.woohoo',
-        })
+        self.portal_user = self.env.ref("base.demo_user0")
         self.portal_user.partner_id.credit_point = 0
 
     def _create_so(self):

--- a/website_sale_credit_point/controllers/website_sale.py
+++ b/website_sale_credit_point/controllers/website_sale.py
@@ -17,7 +17,9 @@ class WebsiteSale(WebsiteSale):
             return redirection
         else:
             try:
-                order.credit_point_check()
+                # we need to check rights on a specific user
+                # instead of admin, as website uses sudo
+                order.credit_point_check(request.env.user)
             except UserError as exc:
                 # error msg if not enought points
                 request.session['credit_point_limit_error'] = exc.name


### PR DESCRIPTION
When we come from the website, self.env.uid is 1, website orders are created by the admin user (sudo) because portal users don't have accesses on the models. So as soon as the user admin has 'sale_credit_point.group_manage_credit_point', all users will bypass the check.